### PR TITLE
Make UI more compact and drag n' drop inside grid

### DIFF
--- a/src/main/web/package.json
+++ b/src/main/web/package.json
@@ -8,6 +8,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@reduxjs/toolkit": "^1.4.0",
     "axios": "^0.20.0",
     "gatsby": "^2.24.50",

--- a/src/main/web/plugins/custom-mui-theme/theme/theme.json
+++ b/src/main/web/plugins/custom-mui-theme/theme/theme.json
@@ -113,7 +113,7 @@
       "color": "rgba(0, 0, 0, 0.87)",
       "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
       "lineHeight": "1.71429em",
-      "fontSize": "0.875rem",
+      "fontSize": "0.625rem",
       "fontWeight": 500
     },
     "caption": {

--- a/src/main/web/src/components/debuff/debuffItem.tsx
+++ b/src/main/web/src/components/debuff/debuffItem.tsx
@@ -10,8 +10,12 @@ interface DebuffItemProps {
 
 const DebuffItem: React.FC<DebuffItemProps> = ({ debuff, activated }) => {
   return (
-    <ListItem disabled={!activated} style={{ marginBottom: 0 }}>
-      <Chip label={debuff.name} />
+    <ListItem disabled={!activated} style={{ marginBottom: 2 }}>
+      <Chip
+        color={!activated ? "default" : "primary"}
+        size="small"
+        label={debuff.name}
+      />
     </ListItem>
   )
 }

--- a/src/main/web/src/components/debuff/debuffList.tsx
+++ b/src/main/web/src/components/debuff/debuffList.tsx
@@ -17,7 +17,11 @@ const DebuffList: React.FC<DebuffListProps> = ({ debuffs, activeDebuffs }) => {
     />
   ))
 
-  return <List>{debuffRows}</List>
+  return (
+    <List dense disablePadding>
+      {debuffRows}
+    </List>
+  )
 }
 
 export default DebuffList

--- a/src/main/web/src/components/raid/partyGrid.tsx
+++ b/src/main/web/src/components/raid/partyGrid.tsx
@@ -26,9 +26,9 @@ const PartyGrid: React.FC<PartyGridTypes> = ({ partyNum, partyValues }) => {
 
   return (
     <Grid item xs={6} style={{ width: 58, textAlign: "center" }}>
-      <Typography variant={"h5"}>{partyNum}</Typography>
+      <Typography variant={"h7"}>{partyNum}</Typography>
       <TableContainer component={Paper}>
-        <Table style={{ margin: 0 }}>
+        <Table size="small" style={{ margin: 0 }}>
           <TableBody>{rows}</TableBody>
         </Table>
       </TableContainer>

--- a/src/main/web/src/components/raid/raidGrid.tsx
+++ b/src/main/web/src/components/raid/raidGrid.tsx
@@ -17,7 +17,7 @@ const RaidGrid: React.FC<RaidGridProps> = ({ numParties, gridValues }) => {
   }
 
   return (
-    <Grid container spacing={2}>
+    <Grid container spacing={2} style={{ height: "fit-content" }}>
       {grids}
     </Grid>
   )

--- a/src/main/web/src/components/spec/specsList.tsx
+++ b/src/main/web/src/components/spec/specsList.tsx
@@ -10,7 +10,7 @@ interface SpecsListProps {
 const SpecsList: React.FC<SpecsListProps> = ({ specs }) => {
   const specsRows = specs.map((spec, i) => <SpecItem key={i} spec={spec} />)
 
-  return <List>{specsRows}</List>
+  return <List dense>{specsRows}</List>
 }
 
 export default SpecsList

--- a/src/main/web/src/pages/index.tsx
+++ b/src/main/web/src/pages/index.tsx
@@ -40,13 +40,13 @@ const IndexPage: React.FC = () => {
         <SEO title="Home" description="" lang="en" meta={[]} />
         <Container>
           <h1>Debuff Planner</h1>
-          <p>
-            Welcome to the Debuff Planner. Here you can set up a raid and plan
-            accordingly.
-          </p>
           <Box display="flex" flexDirection="row">
-            <Box style={{ minWidth: 220, marginRight: 64 }}>{specsLists}</Box>
-            <RaidGrid gridValues={gridValues} numParties={40 / partySize} />
+            <Box display="flex" flexDirection="row">
+              <Box style={{ minWidth: 220, marginRight: 64 }}>{specsLists}</Box>
+              <Box style={{ marginTop: "auto", marginBottom: "auto" }}>
+                <RaidGrid gridValues={gridValues} numParties={40 / partySize} />
+              </Box>
+            </Box>
             <Box style={{ marginLeft: 48 }}>
               <DebuffList debuffs={debuffs} activeDebuffs={activeDebuffs} />
             </Box>

--- a/src/main/web/src/types/app.ts
+++ b/src/main/web/src/types/app.ts
@@ -7,6 +7,7 @@ export const ItemTypes = {
 export interface SpecDragItemType {
   type: string
   value: string
+  prevGridValue: GridValue
 }
 
 export interface SpecsByClasses {

--- a/src/main/web/yarn.lock
+++ b/src/main/web/yarn.lock
@@ -1588,6 +1588,13 @@
     react-is "^16.8.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
+  integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"


### PR DESCRIPTION
* UI is now more compact, everything fits in one screen height (at least on mine it does!)
* Drag n' drop specs in parties to re-arrange, or remove assigned party members by dragging and dropping them outside grid
* Add some color